### PR TITLE
fix: handle null user scenario in EstablishmentCategoryRegistrationHandler

### DIFF
--- a/Source/Handlers/EstablishmentHandlers/EstablishmentCategoryRegistrationHandler.cs
+++ b/Source/Handlers/EstablishmentHandlers/EstablishmentCategoryRegistrationHandler.cs
@@ -1,5 +1,3 @@
-#pragma warning disable CS8602
-
 namespace Comanda.WebApi.Handlers;
 
 public sealed class EstablishmentCategoryRegistrationHandler(
@@ -8,10 +6,14 @@ public sealed class EstablishmentCategoryRegistrationHandler(
     IEstablishmentRepository establishmentRepository
 ) : IRequestHandler<EstablishmentCategoryRegistrationRequest, Response>
 {
-    public async Task<Response> Handle(EstablishmentCategoryRegistrationRequest request,
-                                 CancellationToken cancellationToken)
+    public async Task<Response> Handle(
+        EstablishmentCategoryRegistrationRequest request,
+        CancellationToken cancellationToken
+    )
     {
         var account = await userManager.FindByIdAsync(request.UserId);
+        if (account is null)
+            return new Response(statusCode: 404, message: "user not found");
 
         var establishment = await establishmentRepository.FindSingleAsync(establishment => establishment.Id == request.EstablishmentId);
         if (establishment is null)

--- a/Tests/Repositories.TestingSuite/EstablishmentRepositoryTests/EstablishmentRepository.TestingSuite.cs
+++ b/Tests/Repositories.TestingSuite/EstablishmentRepositoryTests/EstablishmentRepository.TestingSuite.cs
@@ -1,0 +1,50 @@
+
+namespace Comanda.WebApi.TestingSuite.Repositories;
+
+public sealed class EstablishmentRepositoryTestingSuite : IAsyncLifetime
+{
+    private readonly ComandaDbContext _dbContext;
+    private readonly EstablishmentRepository _repository;
+    private readonly IFixture _fixture;
+
+    public EstablishmentRepositoryTestingSuite()
+    {
+        var optionsBuilder = new DbContextOptionsBuilder()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString());
+
+        _dbContext = new ComandaDbContext(optionsBuilder.Options);
+        _repository = new EstablishmentRepository(_dbContext);
+
+        _fixture = new Fixture();
+        _fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+    }
+
+    [Fact(DisplayName = "FindOwnerAsync - Should return establishment owner and related properties")]
+    public async Task FindOwnerAsync_ShouldReturnEstablishmentOwnerAndRelatedProperties()
+    {
+        var establishment = _fixture.Create<Establishment>();
+
+        await _dbContext.Establishments.AddAsync(establishment);
+        await _dbContext.SaveChangesAsync();
+
+        var owner = await _repository.FindOwnerAsync(establishment.Id);
+
+        Assert.NotNull(owner);
+        Assert.NotNull(owner.Account);
+        Assert.Equal(establishment.Owner, owner);
+        Assert.Equal(establishment.Owner.Account.Id, owner.Account.Id);
+        Assert.Equal(establishment.Owner.Account.UserName, owner.Account.UserName);
+    }
+
+
+    public async Task InitializeAsync()
+    {
+        await _dbContext.Database.EnsureCreatedAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dbContext.Database.EnsureDeletedAsync();
+        _dbContext.Dispose();
+    }
+}


### PR DESCRIPTION
### Description
This PR addresses a scenario where the user object retrieved using `userManager.FindByIdAsync` was null. The issue occurred when a request was made with a valid token from a user that no longer existed in the database (due to migration from SQLite to SQL Server where data was not transferred).

### Changes Made
- Added a null check for the `account` object retrieved from `userManager.FindByIdAsync(request.UserId)`.
- If the `account` is null, a 404 response with "user not found" message is returned, preventing further processing.

### Context
The issue was not with the `FindOwnerAsync` method but rather with handling a scenario where the `account` object could be null due to data migration and non-existent user records in the database.

### Testing

Existing unit tests ensure `FindOwnerAsync` method functionality is correct and unaffected by these changes.